### PR TITLE
I fix fact that Getters are supposed to be readonly

### DIFF
--- a/lib/Structures/Statistics.js
+++ b/lib/Structures/Statistics.js
@@ -20,6 +20,7 @@ class Statistics {
 
 	/**
 	 * The {@link BotStatistics} Class used for {@link Statistics#bots|this.bots}
+	 * @readonly
 	 * @type {BotStatistics}
 	 */
 	static get Bots() {


### PR DESCRIPTION
# Pull Request Stuff

**Pull Request Info:** Adds a very quick and dirty `@readonly` tag

**Improves Usability How:** Getters are readonly and throws an error on Strict Mode if attempting to change its value unless there's a Setter >:V

**Reasoning:** Because.

- [ ] Includes changing Library Code
    - [ ] Minor Changes (Var Changes, Method Renames, Property Renames)
    - [ ] Major Changes (Method Renames, Structure Renames, Property to Method, Method to Property, New Functions)
- [x] Includes changing ~~README.md file~~ docs
    - [x] Minor Changes (Typo, Title Rename, Word Replacement)
    - [ ] Major Changes (Everything Else)